### PR TITLE
[front/jaehee] FindInfo->Modal 호출/비밀번호재설정 Modal 생성 등

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,32 +1,47 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import Button from './Button';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import 'bootstrap/dist/css/bootstrap.css';
 
+// 모달의 헤더, 본문, 푸터를 가운데 정렬하는 스타일
+const CenteredModalHeader = styled(ModalHeader)`
+  display: flex;
+  justify-content: center;
+`;
+
+const CenteredModalBody = styled(ModalBody)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const CenteredModalFooter = styled(ModalFooter)`
+  display: flex;
+  justify-content: center;
+`;
+
 const CommonModal = ({ title, contents, btnName, closeModal, redirectTo }) => {
-  // 훅
   const navigate = useNavigate();
 
-  // 버튼 클릭 시, 페이지 이동 및 모달 닫기
   const handleButtonClick = () => {
     if (redirectTo) {
-      navigate(redirectTo); // 버튼 클릭 시 전달받은 페이지 이동
+      navigate(redirectTo);
     }
-    closeModal(); // 모달 닫기
+    closeModal();
   };
+
+  const backdrop = false;
 
   return (
     <div>
-      {/* isOpen은 항상 true : 모달이 항상 열려있음
-      toggle : 모달 열고 닫는 것을 수행하는 함수 (reractstrap 정의)
-      toggle={closeModal} : toggle 속성을 closeModal 함수로 설정 */}
-      <Modal isOpen={true} toggle={closeModal}>
-        <ModalHeader toggle={closeModal}>{title}</ModalHeader>
-        <ModalBody>{contents}</ModalBody>
-        <ModalFooter>
+      <Modal isOpen={true} toggle={closeModal} backdrop={backdrop}>
+        <CenteredModalHeader toggle={closeModal}>{title}</CenteredModalHeader>
+        <CenteredModalBody>{contents}</CenteredModalBody>
+        <CenteredModalFooter>
           <Button onClick={handleButtonClick}>{btnName}</Button>
-        </ModalFooter>
+        </CenteredModalFooter>
       </Modal>
     </div>
   );

--- a/src/pages/findinfo/FindInfo2.js
+++ b/src/pages/findinfo/FindInfo2.js
@@ -5,8 +5,6 @@ import { StyledLogo, RedLetter } from '../../components/Logo';
 import { PiUserCircle } from 'react-icons/pi';
 import { CiMail } from 'react-icons/ci';
 import { GlobalStyle, FindIdContainer, FindPasswordContainer } from './FindInfoStyle';
-import CommonModal from '../../components/Modal';
-import NewPwModal from './NewPwModal';
 
 // FindInfo 컴포넌트
 const FindInfo = () => {
@@ -33,36 +31,6 @@ const FindInfo = () => {
     setNameForPassword('');
     setEmailForPassword('');
     setIdForPassword('');
-  };
-
-  // 모달 열고 닫기 -> false 초기화
-  const [isModalOpen, setModalOpen] = useState(false);
-  // 비밀번호재설정 모달 열고 닫기 -> false 초기화
-  const [isPwModalOpen, setPwModalOpen] = useState(false);
-  // 모달 내용 -> 빈내용 초기화
-  const [modalContent, setModalContent] = useState({});
-  // 비밀번호재설정모달 내용 -> 빈내용 초기화
-  const [pwModalContent, setPwModalContent] = useState({});
-
-  // 모달 열기 함수
-  const openModal = (content) => {
-    setModalOpen(true); // isModalOpen = true
-    setModalContent(content); // 모달 내용 전달
-  };
-  // 모달 닫기 함수
-  const closeModal = () => {
-    setModalOpen(false); // isModalOpen = false
-    setModalContent({}); // 모달 내용 공백 전달
-  };
-  // 모달 열기 함수 (비밀번호재설정 모달)
-  const openPwModal = (content) => {
-    setPwModalOpen(true); // isModalOpen = true
-    setPwModalContent(content); // 모달 내용 전달
-  };
-  // 모달 닫기 함수 (비밀번호재설정 모달)
-  const closePwModal = () => {
-    setPwModalOpen(false); // isModalOpen = false
-    setPwModalContent({}); // 모달 내용 공백 전달
   };
 
   return (
@@ -97,18 +65,7 @@ const FindInfo = () => {
                 value={emailForId}
                 onChange={(e) => setEmailForId(e.target.value)}
               />
-              <Button
-                onClick={() =>
-                  openModal({
-                    title: '아이디 찾기',
-                    contents: '해당 아이디로 다시 로그인 해주세요:)',
-                    btnName: '로그인하기',
-                    redirectTo: '/', // main 페이지 이동
-                  })
-                }
-              >
-                찾기
-              </Button>
+              <Button type='submit'>찾기</Button>
             </div>
           </div>
         </FindIdContainer>
@@ -147,22 +104,9 @@ const FindInfo = () => {
                 value={idForPassword}
                 onChange={(e) => setIdForPassword(e.target.value)}
               />
-              <Button
-                onClick={() =>
-                  openPwModal({
-                    title: '비밀번호 재설정',
-                    contents: '새로운 비밀번호로 로그인 해주세요 :)',
-                    btnName: '로그인하기',
-                    redirectTo: '/', // main 페이지 이동
-                  })
-                }
-              >
-                찾기
-              </Button>
+              <Button type='submit'>찾기</Button>
             </div>
           </div>
-          {isModalOpen && <CommonModal {...modalContent} closeModal={closeModal} />}
-          {isPwModalOpen && <NewPwModal {...pwModalContent} closePwModal={closePwModal} />}
         </FindPasswordContainer>
       </form>
     </>

--- a/src/pages/findinfo/NewPwModal.js
+++ b/src/pages/findinfo/NewPwModal.js
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import Button from '../../components/Button';
+import Input from '../../components/Input';
+import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import 'bootstrap/dist/css/bootstrap.css';
+import { PiUserCircle } from 'react-icons/pi';
+
+// 모달의 헤더, 본문, 푸터를 가운데 정렬하는 스타일
+const CenteredModalHeader = styled(ModalHeader)`
+  display: flex;
+  justify-content: center;
+`;
+
+const CenteredModalBody = styled(ModalBody)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+`;
+
+const CenteredModalFooter = styled(ModalFooter)`
+  display: flex;
+  justify-content: center;
+`;
+
+const NewPwModal = ({ title, contents, btnName, closePwModal, redirectTo }) => {
+  // 훅
+  const navigate = useNavigate();
+
+  // 버튼 클릭 시, 페이지 이동 및 모달 닫기
+  const handleButtonClick = () => {
+    if (redirectTo) {
+      navigate(redirectTo); // 버튼 클릭 시 전달받은 페이지 이동
+    }
+    closePwModal(); // 모달 닫기
+  };
+
+  // 모달 밖 화면 클릭해도 모달 창 닫히지 않도록 설정
+  // 모달 닫을 때는 닫기 버튼으로만 닫히도록 설정
+  const backdrop = false;
+
+  // 비밀번호 재설정
+  const [newPassword, setNewPassword] = useState('');
+  const [checkNewPassword, setCheckNewPassword] = useState('');
+
+  return (
+    <div>
+      <Modal isOpen={true} toggle={closePwModal} backdrop={backdrop}>
+        <CenteredModalHeader toggle={closePwModal}>{title}</CenteredModalHeader>
+        <CenteredModalBody>
+          <p>
+            <PiUserCircle />
+            비밀번호 재설정
+          </p>
+          <Input
+            label='비밀번호 재설정'
+            placeholder='영문, 숫자 포함 최소 8자리'
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+          />
+          <p>
+            <PiUserCircle />
+            비밀번호 확인
+          </p>
+          <Input
+            label='비밀번호 확인'
+            placeholder='위에서 설정한 비밀번호 재입력'
+            value={checkNewPassword}
+            onChange={(e) => setCheckNewPassword(e.target.value)}
+          />
+          {contents}
+        </CenteredModalBody>
+        <CenteredModalFooter>
+          <Button onClick={handleButtonClick}>{btnName}</Button>
+        </CenteredModalFooter>
+      </Modal>
+    </div>
+  );
+};
+
+export default NewPwModal;

--- a/src/pages/main/Main.js
+++ b/src/pages/main/Main.js
@@ -23,31 +23,29 @@ function Main() {
   return (
     <div>
       Main
-      {/* 아이디찾기 버튼 */}
       <Button
         onClick={() =>
           openModal({
-            title: '아이디 찾기',
-            contents: '해당 아이디로 다시 로그인 해주세요:)',
-            btnName: '로그인하기',
-            redirectTo: '/', // main 페이지 이동
+            title: 'findInfo 이동',
+            contents: '이건 연습용 버튼입니다 :)',
+            btnName: 'findInfo',
+            redirectTo: '/findinfo', // findinfo 페이지 이동
           })
         }
       >
-        아이디 찾기
+        findInfo
       </Button>
-      {/* 비밀번호찾기 버튼 */}
       <Button
         onClick={() =>
           openModal({
-            title: '비밀번호 찾기',
+            title: 'ide 이동',
             contents: '새로운 비밀번호를 설정하세요:)',
-            btnName: '확인',
+            btnName: 'ide',
             redirectTo: '/ide', // ide 페이지 이동
           })
         }
       >
-        비밀번호 찾기
+        ide
       </Button>
       {/* isModalOpen 이 true 인 경우에만 && 뒤 실행
       CommonModal 컴포넌트 랜더링, { }는 내용 전달, closeModal에 닫기 함수 전달 */}


### PR DESCRIPTION
+ pages/findinfo/NewPwModal.js 추가
   -findInfo 에서 [비밀번호찾기] 버튼 클릭 시, NewPwModal 랜더링
   -NewPwModal : 기존 공통 Modal 형식 + 새로운 비밀번호 입력받는 Input 추가

+ pages/findinfo/FindIfo.js
   -각 버튼에 맞는 Modal 또는 NewPwModal 랜더링하도록 버튼 부분만 수정
   -위 내용이 반영되기 전 백업 파일 : FindInfo2.js (나중에 삭제 예정)

+Modal.js , NewPwModal.js 공통 
   -내용과 버튼 가운데 정렬 적용
   -모달창 밖(외부) 클릭 시, 모달창 닫히지 않도록 설정
   -모달창 닫을때는 우측 상단 닫기버튼 클릭 시에만 모달창 닫히고 현재 페이지 유지
   -각 모달창에 있는 버튼 클릭 시, 설정한 페이지로 이동